### PR TITLE
Add headers support on endpoints to validate

### DIFF
--- a/lib/assets/templates/setup-esm.js
+++ b/lib/assets/templates/setup-esm.js
@@ -19,7 +19,7 @@ const QUX_SCHEMA = {
 const setup = async () => ({
   httpServer: 'http://foo.bar',
   endpointsToValidate: [{
-    path: '/baz', schema: BAZ_SCHEMA
+    path: '/baz', headers: { foo: 'bar' }, schema: BAZ_SCHEMA
   }, {
     path: '/baz', schema: QUX_SCHEMA
   }]

--- a/lib/assets/templates/setup.js
+++ b/lib/assets/templates/setup.js
@@ -19,7 +19,7 @@ const QUX_SCHEMA = {
 module.exports.setup = async () => ({
   httpServer: 'http://foo.bar',
   endpointsToValidate: [{
-    path: '/baz', schema: BAZ_SCHEMA
+    path: '/baz', headers: { foo: 'bar' }, schema: BAZ_SCHEMA
   }, {
     path: '/baz', schema: QUX_SCHEMA
   }]

--- a/lib/cli/commands/default.js
+++ b/lib/cli/commands/default.js
@@ -46,8 +46,8 @@ const validateEndpoints = async (setup) => {
   const { httpServer, endpointsToValidate } = setup
   return Promise.all(
     endpointsToValidate.map(
-      ({ path, schema }) =>
-        fetch(`${httpServer}${path}`)
+      ({ path, schema, headers }) =>
+        fetch(`${httpServer}${path}`, { headers })
           .then((res) => res.json())
           .then((res) => isValidData(res, schema))
           .then(() => console.success(`${httpServer}${path}  OK`))

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -22,6 +22,9 @@ const SETUP_SCHEMA = {
           },
           schema: {
             type: 'object'
+          },
+          headers: {
+            type: 'object'
           }
         }
       }


### PR DESCRIPTION
Add the possibility to send a `headers` object to be sent as headers on each endpoint to validate request.